### PR TITLE
Add CFLAGS `-O2 -g` to release build script.

### DIFF
--- a/build_emacs_ng.sh
+++ b/build_emacs_ng.sh
@@ -32,7 +32,7 @@ echo arch=$arch
 echo deb_dir=$deb_dir
 echo pkg_name=$pkg_name
 
-./configure CFLAGS="-Wl,-rpath,shared -Wl,--disable-new-dtags" \
+./configure CFLAGS="-Wl,-rpath,shared,--disable-new-dtags -g -O2" \
             --prefix=/usr/local/ \
             --with-json --with-modules --with-harfbuzz --with-compress-install \
             --with-threads --with-included-regex --with-zlib --with-cairo --with-libsystemd \


### PR DESCRIPTION
Motivation:
* parity with traditional emacs release builds
* improved performance (-O2), debuggability without performance loss (-g)

TESTED: manual invocation of ./configure line succeeded on my machine (debian x64 5.10.40).

for comparison, debian emacs(-lucid) 27.1 `system-configuration-options` value is:
```
--build x86_64-linux-gnu --prefix=/usr --sharedstatedir=/var/lib --libexecdir=/usr/lib --localstatedir=/var/lib --infodir=/usr/share/info --mandir=/usr/share/man --enable-libsystemd --with-pop=yes --enable-locallisppath=/etc/emacs:/usr/local/share/emacs/27.1/site-lisp:/usr/local/share/emacs/site-lisp:/usr/share/emacs/27.1/site-lisp:/usr/share/emacs/site-lisp --with-sound=alsa --without-gconf --with-mailutils --build x86_64-linux-gnu --prefix=/usr --sharedstatedir=/var/lib --libexecdir=/usr/lib --localstatedir=/var/lib --infodir=/usr/share/info --mandir=/usr/share/man --enable-libsystemd --with-pop=yes --enable-locallisppath=/etc/emacs:/usr/local/share/emacs/27.1/site-lisp:/usr/local/share/emacs/site-lisp:/usr/share/emacs/27.1/site-lisp:/usr/share/emacs/site-lisp --with-sound=alsa --without-gconf --with-mailutils --with-x=yes --with-x-toolkit=lucid --with-toolkit-scroll-bars --without-gsettings 'CFLAGS=-g -O2 -ffile-prefix-map=/build/emacs-I4DeTU/emacs-27.1+1=. -fstack-protector-strong -Wformat -Werror=format-security -Wall' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' LDFLAGS=-Wl,-z,relro
```